### PR TITLE
CI: update release workflow

### DIFF
--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -132,6 +132,7 @@ jobs:
             twine upload --skip-existing dist/*
 
         - name: Push the Docker image to Quay.io
+          if: ${{ github.event_name == 'release' && github.event.action == 'published' }}
           uses: docker/build-push-action@v5
           with:
             context: .


### PR DESCRIPTION
Limit Docker image push to Quay.io to only occur on official release publication