### PR TITLE
DOCS: Update license from Apache 2.0 to MPL 2.0 in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,17 +270,8 @@ This project was developed and maintained by the following contributors:
 
 Copyright 2023-2024 Lausanne University and Lausanne University Hospital, Switzerland & Contributors
 
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the [License](./LICENSE) for the specific language governing permissions and
-limitations under the License.
+This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. 
+If a copy of the MPL was not distributed with this file, You can obtain one at [http://mozilla.org/MPL/2.0/](http://mozilla.org/MPL/2.0/).
 
 ### Test Data License
 


### PR DESCRIPTION
Fix README license: change from Apache 2.0 to MPL 2.0.
closes #45 