### PR TITLE
CI: Update GitHub Actions Versions

### DIFF
--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -37,7 +37,7 @@ jobs:
 
     steps:
         - name: Checkout code
-          uses: actions/checkout@v3
+          uses: actions/checkout@v4
 
         # Python / Docker setup and registry login
         - name: Set up Python
@@ -87,7 +87,7 @@ jobs:
         
         - name: Docker meta
           id: meta
-          uses: docker/metadata-action@v5.5.1
+          uses: docker/metadata-action@v5
           with:
             images: ${{ env.IMAGE_NAME }}
 


### PR DESCRIPTION
Updates two actions to their latest versions:

- actions/checkout: Upgraded from v3 to v4
- docker/metadata-action: Updated from a specific version v5.5.1 to v5 to ensure future updates automatically apply the latest stable version within v5.

closes #55 