### PR TITLE
FEAT: Add custom folder depth support in tml_ctp_delete_identifiable_dicoms

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ tml_ctp_dat_batcher \
   -s /path/to/dat/script \
   --new-ids /path/to/new_ids.json \
   --day-shift /path/to/day_shift.json
+```
 
 ## How to use `tml_ctp_clean_series_tags`
 
@@ -173,7 +174,7 @@ You can use `delete_identifiable_dicoms.py` for that.
 ### Usage
 
 ```output
-usage: tml_ctp_delete_identifiable_dicoms [-h] --in_folder IN_FOLDER [--delete_T1w] [--delete_T2w]
+usage: tml_ctp_delete_identifiable_dicoms [-h] --in_folder IN_FOLDER [--delete_T1w] [--delete_T2w] [--folder_depth FOLDER_DEPTH]
 
 Delete DICOM files that could lead to identifying the patient.
 
@@ -183,6 +184,7 @@ options:
                         Root dir to the dicom files to be screened for identifiables files.
   --delete_T1w, -t1w    Delete potentially identifiable T1-weighted images such as MPRAGE
   --delete_T2w, -t2w    Delete potentially identifiable T2-weighted images such as FLAIR
+  --folder_depth FOLDER_DEPTH, -fd FOLDER_DEPTH    Specify the folder depth to scan for DICOM files. Default is 3.
 ```
 
 ## For Developers

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -165,3 +165,8 @@ After running `tml_ctp_dat_batcher`, you may need to delete files that could lea
                             Root directory containing the DICOM files to be screened for identifiable data.
       --delete_T1w, -t1w    Delete potentially identifiable T1-weighted images (e.g., MPRAGE).
       --delete_T2w, -t2w    Delete potentially identifiable T2-weighted images (e.g., FLAIR).
+      --folder_depth FOLDER_DEPTH, -fd FOLDER_DEPTH
+                            Specify the folder depth to scan for DICOM files. 
+                            The folder depth refers to how many nested subdirectories should be traversed from the root folder
+                            to reach the DICOM files. The default value is 3, meaning the script expects the DICOM files to be 
+                            in a structure with three levels of subdirectories.

--- a/tests/cli/utils/test_delete_identifiable_dicoms.py
+++ b/tests/cli/utils/test_delete_identifiable_dicoms.py
@@ -1,28 +1,47 @@
-# Copyright 2023-2024 Lausanne University and Lausanne University Hospital, Switzerland & Contributors
-
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, You can obtain one at https://mozilla.org/MPL/2.0/.
-
-"""Define tests for the clean_series_tags CLI script."""
-
 import os
 import shutil
 import glob
 import pydicom
-import pandas as pd
+
+
+def create_custom_folder_structure(source_dir, dest_dir, depth):
+    """
+    Create a custom folder structure with the specified depth.
+
+    Args:
+        source_dir (str): The path to the original directory containing DICOM files.
+        dest_dir (str): The path where the new structure will be created.
+        depth (int): The number of subdirectories to create before placing DICOM files.
+    """
+    if os.path.exists(dest_dir):
+        shutil.rmtree(dest_dir)
+    os.makedirs(dest_dir)
+
+    # Copy each DICOM file from source_dir into the new structure at the specified depth
+    dicom_files = glob.glob(os.path.join(source_dir, "*", "*", "*", "*.dcm"))
+    
+    for idx, dicom_file in enumerate(dicom_files):
+        # Generate subdirectories based on the depth argument
+        subfolder_path = os.path.join(dest_dir, *[f"subdir_{i}" for i in range(depth)])
+
+        # Create the directory if it doesn't exist
+        os.makedirs(subfolder_path, exist_ok=True)
+
+        # Copy the DICOM file to the new location
+        shutil.copy2(dicom_file, os.path.join(subfolder_path, f"dicom_file_{idx}.dcm"))
 
 
 def test_delete_identifiable_dicoms_script_basic(script_runner, test_dir, data_dir):
 
     test_dataset = "PACSMANCohort-delete_identifiable_dicoms"
-    # Copy the dataset to a temporary folder
+    # Copy the dataset to a temporary folder with default structure
+    default_dataset_path = os.path.join(test_dir, "tmp", test_dataset)
     shutil.copytree(
         os.path.join(data_dir, "PACSMANCohort"),
-        os.path.join(test_dir, "tmp", test_dataset),
+        default_dataset_path,
     )
 
-    # Add missing SequenceName to all dicom files in the test_dataset
+    # Add missing SequenceName to all dicom files in the default test_dataset
     dicom_files = glob.glob(
         os.path.join(test_dir, "tmp", test_dataset, "*", "*", "*", "*.dcm")
     )
@@ -31,11 +50,11 @@ def test_delete_identifiable_dicoms_script_basic(script_runner, test_dir, data_d
         ds.SequenceName = "tfl3d"
         ds.save_as(dicom_file)
 
-    # Run the clean_series_tags script
+    # Run the script with default folder depth (3)
     cmd = [
         "tml_ctp_delete_identifiable_dicoms",
         "--in_folder",
-        os.path.join(test_dir, "tmp", test_dataset),
+        default_dataset_path,
         "-t1w",
     ]
 
@@ -43,11 +62,61 @@ def test_delete_identifiable_dicoms_script_basic(script_runner, test_dir, data_d
 
     # Check that the script has run successfully
     assert ret.success
-
     assert "Deleted 128 files" in ret.stdout
 
     # Check that all dicom files have been deleted as SequenceName is tfl3d 
     dicom_files = glob.glob(
-        os.path.join(test_dir, "tmp", test_dataset, "*", "*", "*", "*.dcm")
+        os.path.join(default_dataset_path, "*", "*", "*", "*.dcm")
+    )
+    assert len(dicom_files) == 0
+
+
+def test_delete_identifiable_dicoms_with_custom_depth(script_runner, test_dir, data_dir):
+    """
+    Test the script with a custom folder depth (different from the default).
+    """
+
+    test_dataset = "PACSMANCohort-delete_identifiable_dicoms_custom"
+    custom_depth = 5
+    custom_dataset_path = os.path.join(test_dir, "tmp", f"{test_dataset}_depth_{custom_depth}")
+    original_dataset_path = os.path.join(test_dir, "tmp", f"{test_dataset}_original")
+
+    # Copy the original dataset
+    shutil.copytree(
+        os.path.join(data_dir, "PACSMANCohort"),
+        original_dataset_path,
+    )
+
+    # Add missing SequenceName to all dicom files in the default test_dataset
+    dicom_files = glob.glob(
+        os.path.join(original_dataset_path, "*", "*", "*", "*.dcm")
+    )
+    for dicom_file in dicom_files:
+        ds = pydicom.dcmread(dicom_file)
+        ds.SequenceName = "tfl3d"
+        ds.save_as(dicom_file)
+
+    # Create custom folder structure with depth 5
+    create_custom_folder_structure(original_dataset_path, custom_dataset_path, custom_depth)
+
+    # Run the script with the custom folder depth
+    cmd = [
+        "tml_ctp_delete_identifiable_dicoms",
+        "--in_folder",
+        custom_dataset_path,
+        "-t1w",
+        "--folder_depth",
+        str(custom_depth),  # Provide custom folder depth
+    ]
+
+    ret = script_runner.run(cmd)
+
+    # Check that the script has run successfully for custom depth
+    assert ret.success
+    assert "Deleted 128 files" in ret.stdout
+
+    # Check that all dicom files have been deleted as SequenceName is tfl3d in the custom structure
+    dicom_files = glob.glob(
+        os.path.join(custom_dataset_path, *[f"subdir_{i}" for i in range(custom_depth)], "*.dcm")
     )
     assert len(dicom_files) == 0


### PR DESCRIPTION
- Add --folder_depth argument to tml_ctp_delete_identifiable_dicoms script for handling folders with depth different from 3.
- Add test to verify DICOM deletion with custom folder depth.
- Update docs and README with the new --folder_depth option.

closes #59 