### PR TITLE
CI: Fix path condition to trigger workflow on tml_ctp subfolder changes

### DIFF
--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -11,8 +11,7 @@ on:
       - setup.py
       - setup.cfg
       - docker/*
-      - tml_ctp/*
-      - utils/*
+      - tml_ctp/**
   push:
     tags:
       - '[1-9]+.[0-9]+.[0-9]+' # Only deploy on tags with semantic versioning


### PR DESCRIPTION
- Fixes path condition in GitHub Actions workflow to trigger the workflow correctly when files in tml_ctp/ are modified.
- Removes obsolete path to utils/ from the workflow trigger condition.

closes #62 