### PR TITLE
fix: normalize StudyTime to prevent duplicate session folders for single-session subjects (#70)

### DIFF
--- a/tml_ctp/cli/ctp_dat_batcher.py
+++ b/tml_ctp/cli/ctp_dat_batcher.py
@@ -331,7 +331,7 @@ def rename_ctp_output_subject_folders(CTP_output_folder: str, subject_folder: st
                         ds.StudyDate if hasattr(ds, "StudyDate") else "NoStudyDate"
                     )
                     new_study_time = (
-                        ds.StudyTime if hasattr(ds, "StudyTime") else "NoStudyTime"
+                        ds.StudyTime.split(".")[0] if hasattr(ds, "StudyTime") else "NoStudyTime"
                     )
                     new_series_number = (
                         ds.SeriesNumber


### PR DESCRIPTION
Fixes #70.
When running `tml_ctp_dat_batcher` on Siemens data, some subjects ended up with two session folders instead of one, e.g.:

- `ses-20230115143022`  ← Carestream PACS Reports series
- `ses-20230115143022.123456`  ← actual imaging series

Both represent the same study but produce different folder names because the DICOM `StudyTime` tag format is inconsistent across series: administrative/report series (such as "Carestream PACS Reports") often omit the fractional seconds (`HHMMSS`), while imaging series store the full-precision value (`HHMMSS.FFFFFF`).
## Change
In `rename_ctp_output_subject_folders`, truncate `StudyTime` to its integer-seconds part before constructing the session folder path:
```python
ds.StudyTime.split(".")[0]  # "143022.123456" → "143022"